### PR TITLE
fix: populate local files when used in another folder

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   promptTemplate
 } from './services/generate.services';
 import {installCliIfNecessary} from './services/install.services';
+import type {GeneratorInput} from './types/generator';
 import {checkNodeVersion} from './utils/env.utils';
 import {assertAnswerCtrlC} from './utils/prompts.utils';
 
@@ -19,7 +20,7 @@ export const run = async () => {
 
   // TODO: Welcome text "Hey 👋! Welcome to Juno blahblahblah..."
 
-  const {action}: {action: 'website' | 'app'} = await prompts({
+  const {action}: Pick<GeneratorInput, 'action'> = await prompts({
     type: 'select',
     name: 'action',
     message: 'What type of project do you want to initiate?',

--- a/src/services/generate.services.ts
+++ b/src/services/generate.services.ts
@@ -1,16 +1,10 @@
 import {isNullish} from '@junobuild/utils';
 import {red} from 'kleur';
-import path from 'node:path';
 import prompts from 'prompts';
+import type {GeneratorInput} from '../types/generator';
+import type {Template} from '../types/template';
 import {populate} from '../utils/populate.utils';
 import {assertAnswerCtrlC} from '../utils/prompts.utils';
-
-interface Template {
-  key: string;
-  title: string;
-}
-
-type TemplateStarter = 'blank' | 'tutorial';
 
 const WEBSITE_TEMPLATES: Template[] = [];
 
@@ -72,23 +66,9 @@ export const promptProjectName = async (): Promise<string> => {
   return name;
 };
 
-interface GeneratorInput {
-  action: 'website' | 'app';
-  name: string;
-  template: Template;
-  starter: TemplateStarter | null;
-}
-
-export const generate = async ({action, name, starter, template}: GeneratorInput) => {
-  const templatePath = getTemplatePath(action, template, starter);
+export const generate = async ({name, ...rest}: GeneratorInput) => {
   await populate({
-    templatePath,
-    where: ['.', ''].includes(name) ? null : name
+    where: ['.', ''].includes(name) ? null : name,
+    ...rest
   });
 };
-
-const getTemplatePath = (
-  action: 'website' | 'app',
-  template: Template,
-  starter: TemplateStarter | null
-) => path.join('templates', action, template.key + (starter !== null ? `-${starter}` : ''));

--- a/src/types/generator.ts
+++ b/src/types/generator.ts
@@ -1,0 +1,8 @@
+import type {Template, TemplateStarter} from './template';
+
+export interface GeneratorInput {
+  action: 'website' | 'app';
+  name: string;
+  template: Template;
+  starter: TemplateStarter | null;
+}

--- a/src/types/template.ts
+++ b/src/types/template.ts
@@ -1,0 +1,6 @@
+export interface Template {
+  key: string;
+  title: string;
+}
+
+export type TemplateStarter = 'blank' | 'tutorial';

--- a/src/utils/fs.utils.ts
+++ b/src/utils/fs.utils.ts
@@ -35,6 +35,7 @@ export const getLocalTemplatePath = ({
 } & Pick<GeneratorInput, 'action'>) =>
   join(__dirname, '..', TEMPLATE_PATH, action, templateName(rest));
 
+// TODO: cli-tools
 export const files = (source: string): string[] =>
   readdirSync(source).flatMap((file) => {
     const path = join(source, file);

--- a/src/utils/fs.utils.ts
+++ b/src/utils/fs.utils.ts
@@ -1,0 +1,42 @@
+import {nonNullish} from '@junobuild/utils';
+import {lstatSync, readdirSync} from 'node:fs';
+import {dirname, join} from 'node:path';
+import {fileURLToPath} from 'url';
+import type {GeneratorInput} from '../types/generator';
+import type {Template, TemplateStarter} from '../types/template';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const TEMPLATE_PATH = 'templates';
+
+const templateName = ({
+  template: {key},
+  starter
+}: {
+  template: Template;
+  starter: TemplateStarter | null;
+}): string => `${key}${nonNullish(starter) ? `-${starter}` : ''}`;
+
+export const getRelativeTemplatePath = ({
+  action,
+  ...rest
+}: {
+  template: Template;
+  starter: TemplateStarter | null;
+} & Pick<GeneratorInput, 'action'>) => join(TEMPLATE_PATH, action, templateName(rest));
+
+export const getLocalTemplatePath = ({
+  action,
+  ...rest
+}: {
+  template: Template;
+  starter: TemplateStarter | null;
+} & Pick<GeneratorInput, 'action'>) =>
+  join(__dirname, '..', TEMPLATE_PATH, action, templateName(rest));
+
+export const files = (source: string): string[] =>
+  readdirSync(source).flatMap((file) => {
+    const path = join(source, file);
+    return lstatSync(path).isDirectory() ? files(path) : join(path);
+  });


### PR DESCRIPTION
I build the CLI and tried it in another path to populate some example but, the files were not copied/generated.
This fix the relative/absolute path issues when testing locally.