### PR TITLE
fix: make npm silent to fix socket error

### DIFF
--- a/src/services/cli.services.ts
+++ b/src/services/cli.services.ts
@@ -42,7 +42,7 @@ const install = async (verbose: boolean) => {
       case 'yarn': {
         await spawn({
           command: pm,
-          args: ['global', 'add', CLI_PACKAGE],
+          args: ['--silent', 'global', 'add', CLI_PACKAGE],
           silentOut: !verbose
         });
         break;
@@ -50,7 +50,7 @@ const install = async (verbose: boolean) => {
       default: {
         await spawn({
           command: pm,
-          args: ['install', '--global', CLI_PACKAGE],
+          args: ['install', '--global', CLI_PACKAGE, '--silent'],
           silentOut: !verbose
         });
       }

--- a/src/services/deps.services.ts
+++ b/src/services/deps.services.ts
@@ -19,7 +19,7 @@ export const dependencies = async ({where, verbose}: PopulateInput) => {
 
     await spawn({
       command: pm,
-      args: ['install'],
+      args: ['install', '--silent'],
       silentOut: verbose !== true,
       ...(nonNullish(where) && where !== '' && {cwd: where})
     });

--- a/src/services/deps.services.ts
+++ b/src/services/deps.services.ts
@@ -19,7 +19,7 @@ export const dependencies = async ({where, verbose}: PopulateInput) => {
 
     await spawn({
       command: pm,
-      args: ['install', '--silent'],
+      args: ['--silent', 'install'],
       silentOut: verbose !== true,
       ...(nonNullish(where) && where !== '' && {cwd: where})
     });


### PR DESCRIPTION
❯ node /Users/daviddalbusco/projects/juno/create-juno/dist/index.js
  __  __ __  __  _  ____ 
__) ||  |  ||  \| |/    \
\___/ \___/ |_|\__|\____/ v0.0.21

Welcome 👋

✔ Where should we create your project? … 12345678
✔ What kind of project are you starting? › Application
✔ Which framework do you want to use? › React
✔ Choose your starting point? › Example
✔ Would you like to set up a GitHub Action for deployment?
  Remember, you'll need to configure a controller afterward. Check our documentation for more details … no / yes
✔ Do you want to configure the project to use the local development emulator? … no / yes
✔ Install your project's dependencies now? … no / yes
An unexpected error happened 😫. Error: npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.

    at Socket.<anonymous> (file:///Users/daviddalbusco/projects/juno/create-juno/dist/index.js:2096:8966)
    at Socket.emit (node:events:519:28)
    at addChunk (node:internal/streams/readable:559:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:510:3)
    at Readable.push (node:internal/streams/readable:390:5)
    at Pipe.onStreamRead (node:internal/stream_base_commons:191:23)