### PR TITLE
fix: polyfill global for agent-js

### DIFF
--- a/templates/angular-example/src/main.ts
+++ b/templates/angular-example/src/main.ts
@@ -2,4 +2,9 @@ import {bootstrapApplication} from '@angular/platform-browser';
 import {AppComponent} from './app/app.component';
 import {appConfig} from './app/app.config';
 
+// Agent-js requires a polyfill 😕
+// I've reported this issue multiple times. Hopefully, it will be addressed in the future.
+// ERROR ReferenceError: global is not defined
+(window as any).global = window;
+
 bootstrapApplication(AppComponent, appConfig).catch((err) => console.error(err));

--- a/templates/angular-starter/src/main.ts
+++ b/templates/angular-starter/src/main.ts
@@ -2,4 +2,9 @@ import {bootstrapApplication} from '@angular/platform-browser';
 import {AppComponent} from './app/app.component';
 import {appConfig} from './app/app.config';
 
+// Agent-js requires a polyfill 😕
+// I've reported this issue multiple times. Hopefully, it will be addressed in the future.
+// ERROR ReferenceError: global is not defined
+(window as any).global = window;
+
 bootstrapApplication(AppComponent, appConfig).catch((err) => console.error(err));

--- a/templates/react-example/package.json
+++ b/templates/react-example/package.json
@@ -32,6 +32,12 @@
     "postcss": "^8.4.49",
     "prettier": "^3.4.2",
     "tailwindcss": "^3.4.16",
-    "vite": "^6.0.3"
+    "vite": "^6.0.3",
+    "vite-plugin-node-polyfills": "^0.22.0"
+  },
+  "overrides": {
+    "vite-plugin-node-polyfills": {
+      "vite": "^6.0.0"
+    }
   }
 }

--- a/templates/react-example/vite.config.js
+++ b/templates/react-example/vite.config.js
@@ -1,8 +1,9 @@
 import juno from '@junobuild/vite-plugin';
 import react from '@vitejs/plugin-react';
 import {defineConfig} from 'vite';
+import {nodePolyfills} from 'vite-plugin-node-polyfills';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), juno({container: true})]
+  plugins: [react(), nodePolyfills(), juno({container: true})]
 });

--- a/templates/react-starter/package.json
+++ b/templates/react-starter/package.json
@@ -31,6 +31,12 @@
     "postcss": "^8.4.49",
     "prettier": "^3.4.2",
     "tailwindcss": "^3.4.16",
-    "vite": "^6.0.3"
+    "vite": "^6.0.3",
+    "vite-plugin-node-polyfills": "^0.22.0"
+  },
+  "overrides": {
+    "vite-plugin-node-polyfills": {
+      "vite": "^6.0.0"
+    }
   }
 }

--- a/templates/react-starter/vite.config.js
+++ b/templates/react-starter/vite.config.js
@@ -1,8 +1,9 @@
 import juno from '@junobuild/vite-plugin';
 import react from '@vitejs/plugin-react';
 import {defineConfig} from 'vite';
+import {nodePolyfills} from 'vite-plugin-node-polyfills';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), juno({container: true})]
+  plugins: [react(), nodePolyfills(), juno({container: true})]
 });

--- a/templates/react-workshop/package.json
+++ b/templates/react-workshop/package.json
@@ -32,6 +32,12 @@
     "postcss": "^8.4.49",
     "prettier": "^3.4.2",
     "tailwindcss": "^3.4.16",
-    "vite": "^6.0.3"
+    "vite": "^6.0.3",
+    "vite-plugin-node-polyfills": "^0.22.0"
+  },
+  "overrides": {
+    "vite-plugin-node-polyfills": {
+      "vite": "^6.0.0"
+    }
   }
 }

--- a/templates/react-workshop/vite.config.js
+++ b/templates/react-workshop/vite.config.js
@@ -1,8 +1,9 @@
 import juno from '@junobuild/vite-plugin';
 import react from '@vitejs/plugin-react';
 import {defineConfig} from 'vite';
+import { nodePolyfills } from 'vite-plugin-node-polyfills';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), juno({container: true})]
+  plugins: [react(), nodePolyfills(), juno({container: true})]
 });

--- a/templates/vanilla-js-example/package.json
+++ b/templates/vanilla-js-example/package.json
@@ -17,10 +17,16 @@
     "autoprefixer": "^10.4.20",
     "prettier": "^3.4.2",
     "tailwindcss": "^3.4.16",
-    "vite": "^6.0.3"
+    "vite": "^6.0.3",
+    "vite-plugin-node-polyfills": "^0.22.0"
   },
   "dependencies": {
     "@junobuild/core": "^0.1.0",
     "nanoid": "^5.0.9"
+  },
+  "overrides": {
+    "vite-plugin-node-polyfills": {
+      "vite": "^6.0.0"
+    }
   }
 }

--- a/templates/vanilla-js-example/vite.config.js
+++ b/templates/vanilla-js-example/vite.config.js
@@ -1,7 +1,8 @@
 import juno from '@junobuild/vite-plugin';
 import {defineConfig} from 'vite';
+import { nodePolyfills } from 'vite-plugin-node-polyfills';
 
 /** @type {import('vite').UserConfig} */
 export default defineConfig({
-  plugins: [juno({container: true})]
+  plugins: [nodePolyfills(), juno({container: true})]
 });

--- a/templates/vue-example/package.json
+++ b/templates/vue-example/package.json
@@ -45,8 +45,14 @@
     "tailwindcss": "^3.4.16",
     "typescript": "~5.6.3",
     "vite": "^6.0.1",
+    "vite-plugin-node-polyfills": "^0.22.0",
     "vite-plugin-vue-devtools": "^7.6.5",
     "vitest": "^2.1.5",
     "vue-tsc": "^2.1.10"
+  },
+  "overrides": {
+    "vite-plugin-node-polyfills": {
+      "vite": "^6.0.0"
+    }
   }
 }

--- a/templates/vue-example/vite.config.ts
+++ b/templates/vue-example/vite.config.ts
@@ -4,10 +4,11 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueJsx from '@vitejs/plugin-vue-jsx'
 import juno from '@junobuild/vite-plugin'
+import { nodePolyfills } from 'vite-plugin-node-polyfills'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [vue(), vueJsx(), juno({ container: true })],
+  plugins: [vue(), vueJsx(), nodePolyfills(), juno({ container: true })],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),

--- a/templates/vue-starter/package.json
+++ b/templates/vue-starter/package.json
@@ -44,8 +44,14 @@
     "tailwindcss": "^3.4.16",
     "typescript": "~5.6.3",
     "vite": "^6.0.1",
+    "vite-plugin-node-polyfills": "^0.22.0",
     "vite-plugin-vue-devtools": "^7.6.5",
     "vitest": "^2.1.5",
     "vue-tsc": "^2.1.10"
+  },
+  "overrides": {
+    "vite-plugin-node-polyfills": {
+      "vite": "^6.0.0"
+    }
   }
 }

--- a/templates/vue-starter/vite.config.ts
+++ b/templates/vue-starter/vite.config.ts
@@ -4,10 +4,11 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueJsx from '@vitejs/plugin-vue-jsx'
 import juno from '@junobuild/vite-plugin'
+import { nodePolyfills } from 'vite-plugin-node-polyfills'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [vue(), vueJsx(), juno({ container: true })],
+  plugins: [vue(), vueJsx(), nodePolyfills(), juno({ container: true })],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),


### PR DESCRIPTION
Agent-js requires various NodeJS polyfill in Vite and Webpack projects. Given that' `@junobuild/core` now uses Agent-js as a peer dependencies, those templates were failing calling the IC due to the lack of polyfill for `global`.

Resolves #59