### PR TITLE
feat: svelte-kit sync for CI breaking change

### DIFF
--- a/templates/sveltekit-example/package.json
+++ b/templates/sveltekit-example/package.json
@@ -5,6 +5,7 @@
 	"scripts": {
 		"dev": "vite dev",
 		"build": "tsc --noEmit && vite build",
+		"prepare": "svelte-kit sync",
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/templates/sveltekit-starter/package.json
+++ b/templates/sveltekit-starter/package.json
@@ -5,6 +5,7 @@
 	"scripts": {
 		"dev": "vite dev",
 		"build": "tsc --noEmit && vite build",
+		"prepare": "svelte-kit sync",
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",


### PR DESCRIPTION
Last version of SvelteKit requires `"prepare": "svelte-kit sync",` otherwise CI fails.