### PR TITLE
fix: missing deps build_react_ts_example to publish template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ RUN ./docker/compress react-starter
 FROM deps as build_react_ts_starter
 RUN ./docker/compress react-ts-starter
 
+FROM deps as build_react_ts_example
+RUN ./docker/compress react-ts-example
+
 FROM deps as build_react_example
 RUN ./docker/compress react-example
 


### PR DESCRIPTION
My gosh so many tries...

Fix https://github.com/junobuild/create-juno/actions/runs/13738957639/job/38425944735