### PR TITLE
feat: use boilerplate for GH Actions and remove build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,4 @@ templates/**/package-lock.json
 /playwright/.cache/
 
 # We generate this on publish
-boilerplate
+boilerplate/functions

--- a/boilerplate/github/deploy.yml
+++ b/boilerplate/github/deploy.yml
@@ -1,4 +1,4 @@
-export const GITHUB_ACTION_DEPLOY = `name: Deploy to Juno
+name: Deploy to Juno
 
 on:
   workflow_dispatch:
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -25,4 +25,4 @@ jobs:
         with:
           args: deploy
         env:
-          JUNO_TOKEN: $\{{ secrets.JUNO_TOKEN }}`
+          JUNO_TOKEN: ${{ secrets.JUNO_TOKEN }}

--- a/scripts/cli-to-boilerplate.sh
+++ b/scripts/cli-to-boilerplate.sh
@@ -5,15 +5,14 @@ set -e
 NPM_ROOT=$(npm root -g)
 SRC="$NPM_ROOT/@junobuild/cli/templates/eject"
 
-DEST="./boilerplate"
-DEST_FUNCTIONS="$DEST/functions"
+DEST="./boilerplate/functions"
 
 if [ -d "$DEST" ]; then
   rm -rf "$DEST"
 fi
 
-mkdir -p "$DEST_FUNCTIONS"
+mkdir -p "$DEST"
 
-cp -r "$SRC/"* "$DEST_FUNCTIONS/"
+cp -r "$SRC/"* "$DEST/"
 
 echo "✅ Boilerplate copied to $DEST"

--- a/src/services/generate.services.ts
+++ b/src/services/generate.services.ts
@@ -6,11 +6,11 @@ import {writeFile} from 'node:fs/promises';
 import {basename, join, parse} from 'node:path';
 import ora from 'ora';
 import {BOILERPLATE_PATH, JUNO_CDN_URL} from '../constants/constants';
-import {GITHUB_ACTION_DEPLOY} from '../templates/github-actions';
 import type {PopulateInput, ServerlessFunctions} from '../types/generator';
 import {untarFile, type UntarOutputFile} from '../utils/compress.utils';
 import {
   copyFiles,
+  createFolders,
   createParentFolders,
   getLocalTemplatePath,
   getRelativeTemplatePath
@@ -125,11 +125,13 @@ const populateFromLocal = async ({where, template, localDevelopment}: PopulateIn
 };
 
 const populateGitHubAction = async ({where}: PopulateInputFn) => {
-  const target = join(where ?? '', '.github', 'workflows', 'deploy.yaml');
+  const target = join(where ?? '', '.github', 'workflows');
 
-  createParentFolders(target);
+  createFolders(target);
 
-  await writeFile(target, GITHUB_ACTION_DEPLOY);
+  const source = join(BOILERPLATE_PATH, 'github');
+
+  await copyFiles({source, target});
 };
 
 const updatePackageJson = async ({

--- a/src/utils/fs.utils.ts
+++ b/src/utils/fs.utils.ts
@@ -17,9 +17,15 @@ export const getLocalTemplatePath = ({key}: {key: TemplateKey}) =>
 export const createParentFolders = (target: string) => {
   const folder = dirname(target);
 
-  if (!existsSync(folder)) {
-    mkdirSync(folder, {recursive: true});
+  createFolders(folder);
+};
+
+export const createFolders = (folder: string) => {
+  if (existsSync(folder)) {
+    return;
   }
+
+  mkdirSync(folder, {recursive: true});
 };
 
 export const copyFiles = async ({source, target}: {source: string; target: string}) => {


### PR DESCRIPTION
- We can use the new `boilerplate` folder to hold the GitHub Actions template
- We can also review its content and remove the build step as it is now integrated in the predeploy