### PR TITLE
chore: redo cdn satellite id

### DIFF
--- a/juno.config.ts
+++ b/juno.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   satellite: {
     ids: {
       development: 'jx5yt-yyaaa-aaaal-abzbq-cai',
-      production: '<PROD_SATELLITE_ID>'
+      production: 'fmkjf-bqaaa-aaaal-acpza-cai'
     },
     source: 'out',
     storage: {


### PR DESCRIPTION
I incorrectly removed the prod satellite id in  #159 (I forgot the templates are published in the CDN 😅).